### PR TITLE
Hide "View in Lizard-button" on small screens

### DIFF
--- a/src/components/FullLayout.css
+++ b/src/components/FullLayout.css
@@ -37,6 +37,12 @@
   right: 10px;
   top: 10px;
 }
+@media only screen and (max-width: 700px) {
+  .ViewInLizardButton {
+    display: none;
+  }
+}
+
 .ViewInLizardButton a {
   text-transform: uppercase;
   font-size: 13px;


### PR DESCRIPTION
Wide, shown:
![screen shot 2017-10-26 at 11 28 28](https://user-images.githubusercontent.com/7193/32045537-d52f4f72-ba40-11e7-810b-e4fdcbcdbd54.jpg)

Narrow, hidden:
![screen shot 2017-10-26 at 11 28 34](https://user-images.githubusercontent.com/7193/32045535-d51854fc-ba40-11e7-8aee-68132c2a0025.jpg)

Fixes https://github.com/nens/parramatta-dashboard/issues/35