### PR TITLE
Function over fashion: removes gradients from chart component

### DIFF
--- a/src/components/TimeseriesChart.js
+++ b/src/components/TimeseriesChart.js
@@ -5,7 +5,7 @@ import "moment/locale/en-au";
 import { addTimeseries } from "../actions";
 import { getTimeseries } from "lizard-api-client";
 import {
-  Area,
+  Line,
   Bar,
   CartesianGrid,
   ComposedChart,
@@ -315,11 +315,10 @@ class TimeseriesChartComponent extends Component {
 
       if (observationType.scale === "interval") {
         return (
-          <Area
+          <Line
             key={uuid}
             yAxisId={axisIndex}
             connectNulls={true}
-            fill="url(#lineChartGradient)"
             fillOpacity={1}
             dot={false}
             name={observationType.getLegendString()}
@@ -458,12 +457,6 @@ class TimeseriesChartComponent extends Component {
           right: 2 * margin
         }}
       >
-        <defs>
-          <linearGradient id="lineChartGradient" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="#26A7F1" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="#26A7F1" stopOpacity={0} />
-          </linearGradient>
-        </defs>
         {grid}
         {lines}
         {xaxis}


### PR DESCRIPTION
A bug in Firefox for iOS with SVG gradients caused us change this back to lines without gradients.

Fixes https://github.com/nens/parramatta-dashboard/issues/36

![screen shot 2017-10-26 at 13 36 27](https://user-images.githubusercontent.com/7193/32050858-afa229c0-ba52-11e7-85a1-07741a389fcb.jpg)

