### PR TITLE
Always show terms modal

### DIFF
--- a/src/TermsOrLoginOrApp.js
+++ b/src/TermsOrLoginOrApp.js
@@ -26,7 +26,6 @@ class TermsOrLoginOrAppComponent extends Component {
   }
 
   termsSigned() {
-    window.localStorage.setItem("termsSigned", "true");
     this.setState({ termsSigned: true });
   }
 


### PR DESCRIPTION
For development, you can set `termsSigned` manually in localstorage:
In your dev console, type:

`localStorage.setItem("termsSigned", true)`

Fixes https://github.com/nens/parramatta-dashboard/issues/38