### PR TITLE
Only load/show what's in view (using waypoints)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-router-dom": "^4.2.2",
     "react-tap-event-plugin": "^3.0.2",
     "react-transition-group": "^2.2.1",
+    "react-waypoint": "^8.0.1",
     "recharts": "^1.0.0-apha.5",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",

--- a/src/components/GridLayout.js
+++ b/src/components/GridLayout.js
@@ -340,9 +340,7 @@ class GridLayout extends Component {
           >
             {tileComponents.map((component, i) => {
               return (
-                // <Waypoint key={i} onEnter={(e) => console.log("entering", e)}>
                 <div key={i}>{component}</div>
-                // </Waypoint>
               );
             })}
           </div>

--- a/src/components/GridLayout.js
+++ b/src/components/GridLayout.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import DocumentTitle from "react-document-title";
 import { connect } from "react-redux";
-import ReactGridLayout from "react-grid-layout";
 import Tile from "./Tile";
 import Ink from "react-ink";
 import { withRouter } from "react-router-dom";
@@ -25,8 +24,6 @@ class GridLayout extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      canMove: false,
-      layout: null,
       width: window.innerWidth,
       height: window.innerHeight,
       settingsMenu: false,
@@ -34,37 +31,6 @@ class GridLayout extends Component {
     };
     this.handleUpdateDimensions = this.handleUpdateDimensions.bind(this);
     this.handleKeyPress = this.handleKeyPress.bind(this);
-  }
-  componentWillMount() {
-    if (!this.state.layout) {
-      this.setState({
-        mobileLayout: this.props.tiles.map((tile, i) => {
-          const y = 8;
-          return {
-            i: `${i}`,
-            x: 0,
-            y: i * 8,
-            w: 12,
-            h: y,
-            minW: 2,
-            maxW: 12
-          };
-        }),
-        layout: this.props.tiles.map((tile, i) => {
-          const w = 4;
-          const y = 8;
-          return {
-            i: `${i}`,
-            x: (i * 4) % 12,
-            y: Math.floor(i / 6) * y,
-            w: w,
-            h: y,
-            minW: 2,
-            maxW: 4
-          };
-        })
-      });
-    }
   }
   componentDidMount() {
     window.addEventListener("resize", this.handleUpdateDimensions, false);
@@ -99,7 +65,7 @@ class GridLayout extends Component {
   }
 
   render() {
-    const { width, height, canMove, settingsMenu, settingsMenuId } = this.state;
+    const { width, height, settingsMenu, settingsMenuId } = this.state;
     const { tiles, history } = this.props;
 
     const nensMail = () => unescape("servicedesk%40nelen%2Dschuurmans%2Enl");
@@ -364,20 +330,22 @@ class GridLayout extends Component {
             )}
             <Ink />
           </div>
-          <ReactGridLayout
-            isDraggable={canMove}
-            isResizable={canMove}
-            className="layout"
-            layout={width < 700 ? this.state.mobileLayout : this.state.layout}
-            cols={12}
-            rowHeight={30}
-            width={width - 20 /* This eleminates the horizontal scrollbar */}
-            draggableHandle=".drag-handle"
+          <div
+            style={{
+              display: "grid",
+              width: "calc(100% - 10px)",
+              gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
+              gridGap: 10
+            }}
           >
             {tileComponents.map((component, i) => {
-              return <div key={i}>{component}</div>;
+              return (
+                // <Waypoint key={i} onEnter={(e) => console.log("entering", e)}>
+                <div key={i}>{component}</div>
+                // </Waypoint>
+              );
             })}
-          </ReactGridLayout>
+          </div>
           <footer className={styles.Footer}>Nelen &amp; Schuurmans</footer>
         </div>
       </DocumentTitle>

--- a/src/components/Tile.css
+++ b/src/components/Tile.css
@@ -6,6 +6,8 @@
   box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, 0.29);
   border: 2px solid #fff;
   overflow: hidden;
+  position: relative;
+  height: 300px;
 }
 .TileTitle {
   position: absolute;
@@ -16,7 +18,6 @@
   overflow: hidden;
   cursor: grab;
   z-index: 999999;
-
   background-color: #16a085;
 }
 .TileTitle:active {

--- a/src/components/Tile.js
+++ b/src/components/Tile.js
@@ -1,24 +1,42 @@
 import React, { Component } from "react";
+import Waypoint from "react-waypoint";
 import styles from "./Tile.css";
 
 class Tile extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      show: false
+    };
+  }
   render() {
     const { onClick, title, children, backgroundColor } = this.props;
+    const { show } = this.state;
 
     return (
-      <div
-        style={{
-          backgroundColor: backgroundColor ? backgroundColor : "#ffffff"
+      <Waypoint
+        onEnter={e => {
+          if (e.currentPosition === "inside") {
+            this.setState({
+              show: true
+            });
+          }
         }}
-        className={styles.Tile}
-        onClick={onClick}
       >
-        <div className={styles.TileTitle}>
-          <div className="drag-handle">{title}</div>
-          <i className={`${styles.TileHandle} material-icons`}>more_vert</i>
+        <div
+          style={{
+            backgroundColor: backgroundColor ? backgroundColor : "#ffffff"
+          }}
+          className={styles.Tile}
+          onClick={onClick}
+        >
+          <div className={styles.TileTitle}>
+            <div className="drag-handle">{title}</div>
+            <i className={`${styles.TileHandle} material-icons`}>more_vert</i>
+          </div>
+          {show ? children : null}
         </div>
-        {children}
-      </div>
+      </Waypoint>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,6 +1618,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+consolidated-events@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/consolidated-events/-/consolidated-events-1.1.1.tgz#25395465b35e531395418b7bbecb5ecaf198d179"
+
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -5868,6 +5872,14 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, pr
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.0.0:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@~15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
@@ -6193,6 +6205,13 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.5.8"
     warning "^3.0.0"
+
+react-waypoint@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-waypoint/-/react-waypoint-8.0.1.tgz#00f7694a9d54da5a50be859da5dde96b1795b892"
+  dependencies:
+    consolidated-events "^1.1.0"
+    prop-types "^15.0.0"
 
 "react@^15 || ^16", react@^16.0.0:
   version "16.0.0"


### PR DESCRIPTION
Demo (YouTube video): 

<a href="https://youtu.be/d_thtiKCN7I" target="_blank"><img src="https://user-images.githubusercontent.com/7193/41096888-5b0c3176-6a56-11e8-9161-725e7489248b.jpg" alt="YouTube video of this PR" width="400px"/></a>
[https://youtu.be/d_thtiKCN7I](https://youtu.be/d_thtiKCN7I)

Pro:

- Easier on the bandwidth (loads only whats visible, more only on scrolling) which is especially useful for mobile devices

Con:

- No longer uses react-grid-layout (I wrongly anticipated we would need it but we never used it)

