### PR TITLE
Implement the fake training data modus for timeseries events

### DIFF
--- a/src/fakeData.js
+++ b/src/fakeData.js
@@ -1,0 +1,59 @@
+import { combineReducers } from "redux";
+import { RECEIVE_BOOTSTRAP_SUCCESS } from "./actions";
+import { processMultipleResultsResponse } from "lizard-api-client";
+
+// Redux reducer and selectors for storing and using fake data,
+// to use in the Training Mode. Consists of separate sub-reducers for
+// timeseries, rasterdata, timeseriesalarms and rasteralarms.
+
+// The state of fakeData is only changed once, when the Bootstrap is received;
+// if it contains fake data, then it is parsed using lizard-api-client here
+// and saved. Then it can be used instead of sending actual API requests.
+
+// "Start" and "end" timestamps are ignored as it assumed all fake data covers
+// the same time period.
+
+// Each type of request has its own reducer, that are combined in the Redux state.
+
+function fakeTimeseriesData(state = {}, action) {
+  // The state of fakeTimeseriesData has uuids as keys, and parsed
+  // results of API calls as values.
+  if (action.type !== RECEIVE_BOOTSTRAP_SUCCESS) {
+    return state;
+  }
+
+  const config = action.bootstrap.configuration;
+
+  if (!config || !config.fakeData || !config.fakeData.timeseries) {
+    return state;
+  }
+
+  const newState = {};
+
+  Object.keys(config.fakeData.timeseries).forEach(uuid => {
+    const timeseriesData = config.fakeData.timeseries[uuid];
+    const parsed = processMultipleResultsResponse(
+      "Timeseries",
+      timeseriesData,
+      "http://example.com"
+    );
+
+    if (parsed) {
+      newState[uuid] = parsed;
+    }
+  });
+
+  return newState;
+}
+
+export const fakeDataReducer = combineReducers({
+  timeseries: fakeTimeseriesData
+});
+
+// Selectors
+
+// It is a bit sad that functions in this file have to know that they are called
+// fakeData in the global state, but I don't know how to avoid that.
+export const getFakeTimeseriesData = function(state, uuid) {
+  return state.fakeData && state.fakeData.timeseries[uuid];
+};

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -18,6 +18,7 @@ import {
   RECEIVE_BOOTSTRAP_SUCCESS,
   SET_IFRAME_MODE
 } from "./actions";
+import { fakeDataReducer } from "./fakeData";
 import { MAP_BACKGROUNDS } from "./config";
 
 import { makeReducer } from "lizard-api-client";
@@ -292,6 +293,8 @@ function alarms(
   }
 }
 
+// Fake Data for the training modes.
+
 const rootReducer = combineReducers({
   alarms,
   assets,
@@ -302,7 +305,8 @@ const rootReducer = combineReducers({
   timeseriesEvents,
   rasterEvents,
   settings,
-  iframeMode
+  iframeMode,
+  fakeData: fakeDataReducer
 });
 
 export default rootReducer;


### PR DESCRIPTION
Er is een reducer die "fakeData" uit de bootstrap opslaat op de Redux state wanneer de bootstrap binnenkomt, op dezelfde manier verwerkt als dat lizard-api-client normale API responses verwerkt.

De fetch timeseries events actie kijkt of er zulke fake data bestaat en gebruikt die in dat geval, in plaats van een request te doen.

Er is een test slug, bij http://localhost:3000/floodsmart/parr-remco-fakedata zou de onderste grafiek een piek naar 2 en naar -1 moeten hebben. En vast blijven staan op het tijdstip waarop ik hem gemaakt heb, weet nog niet wat dat gaat doen (waarschijnlijk moet de "nu" in die slug ook vastgezet worden, dat was nu ook gemerged geloof ik?)